### PR TITLE
Use gopkg.in/blackfriday.v2

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/ahmetb/gen-crd-api-reference-docs
 require (
 	github.com/pkg/errors v0.8.1
 	github.com/pmezard/go-difflib v1.0.0 // indirect
-	github.com/russross/blackfriday/v2 v2.0.1
+	gopkg.in/russross/blackfriday.v2 v2.0.1
 	github.com/shurcooL/sanitized_anchor_name v1.0.0 // indirect
 	github.com/spf13/pflag v1.0.3 // indirect
 	golang.org/x/tools v0.0.0-20190213192042-740235f6c0d8 // indirect

--- a/main.go
+++ b/main.go
@@ -21,7 +21,7 @@ import (
 	"unicode"
 
 	"github.com/pkg/errors"
-	"github.com/russross/blackfriday/v2"
+	blackfriday "gopkg.in/russross/blackfriday.v2"
 	"k8s.io/gengo/parser"
 	"k8s.io/gengo/types"
 	"k8s.io/klog"


### PR DESCRIPTION
This enables compatibility with dep until dep supports go mod's version suffixes. Compatibility with dep is required to vendor this repo in https://github.com/knative/docs.

See https://github.com/matcornic/hermes/issues/46