### PR TITLE
Always add package path to typeIdentifier

### DIFF
--- a/main.go
+++ b/main.go
@@ -286,10 +286,7 @@ func typeIdentifier(t *types.Type, c generatorConfig) string {
 	for tt.Elem != nil {
 		tt = tt.Elem
 	}
-	if !isLocalType(t) {
-		return tt.Name.String() // {PackagePath.Name}
-	}
-	return tt.Name.Name // just {Name}
+	return tt.Name.String() // {PackagePath.Name}
 }
 
 // linkForType returns an anchor to the type if it can be generated. returns
@@ -347,6 +344,9 @@ func linkForType(t *types.Type, c generatorConfig) (string, error) {
 
 func typeDisplayName(t *types.Type, c generatorConfig) string {
 	s := typeIdentifier(t, c)
+	if isLocalType(t) {
+		s = t.Name.Name
+	}
 	if t.Kind == types.Pointer {
 		s = strings.TrimLeft(s, "*")
 	}

--- a/template/pkg.tpl
+++ b/template/pkg.tpl
@@ -27,7 +27,7 @@
     {{- range (visibleTypes (sortedTypes .Types)) -}}
         {{ if isExportedType . -}}
         <li>
-            <a href="#{{ typeIdentifier . }}">{{ typeIdentifier . }}</a>
+            <a href="#{{ typeIdentifier . }}">{{ typeDisplayName . }}</a>
         </li>
         {{- end }}
     {{- end -}}

--- a/template/type.tpl
+++ b/template/type.tpl
@@ -1,6 +1,6 @@
 {{ define "type" }}
 
-<h3 id="{{ .Name.Name }}">
+<h3 id="{{ typeIdentifier . }}">
     {{- .Name.Name }}
     {{ if eq .Kind "Alias" }}(<code>{{.Underlying}}</code> alias)</p>{{ end -}}
 </h3>


### PR DESCRIPTION
The eventing api defines the `ChannelSpec` type in two local packages, but the reference docs were generated without a package path so the links to those types were . This change ensures all type identifiers are unique across local packages.

`linkForType` and `typeDisplayName` have been updated to work with the new behavior, and the templates now uses `typeIdentifier` and `typeDisplayName` consistently.