### PR TITLE
Permalinks for anchors

### DIFF
--- a/template/members.tpl
+++ b/template/members.tpl
@@ -7,7 +7,7 @@
         <code>{{ fieldName . }}</code></br>
         <em>
             {{ if linkForType .Type }}
-                <a href="{{linkForType .Type}}">
+                <a href="{{ linkForType .Type}}">
                     {{ typeDisplayName .Type }}
                 </a>
             {{ else }}

--- a/template/pkg.tpl
+++ b/template/pkg.tpl
@@ -27,7 +27,7 @@
     {{- range (visibleTypes (sortedTypes .Types)) -}}
         {{ if isExportedType . -}}
         <li>
-            <a href="#{{ typeIdentifier . }}">{{ typeDisplayName . }}</a>
+            <a href="{{ linkForType . }}">{{ typeDisplayName . }}</a>
         </li>
         {{- end }}
     {{- end -}}

--- a/template/type.tpl
+++ b/template/type.tpl
@@ -1,6 +1,6 @@
 {{ define "type" }}
 
-<h3 id="{{ typeIdentifier . }}">
+<h3 id="{{ anchorIDForType . }}">
     {{- .Name.Name }}
     {{ if eq .Kind "Alias" }}(<code>{{.Underlying}}</code> alias)</p>{{ end -}}
 </h3>
@@ -11,7 +11,7 @@
         {{- range . -}}
             {{- if $prev -}}, {{ end -}}
             {{ $prev = . }}
-            <a href="#{{ typeIdentifier . }}">{{ typeDisplayName . }}</a>
+            <a href="{{ linkForType . }}">{{ typeDisplayName . }}</a>
         {{- end -}}
         )
     </p>


### PR DESCRIPTION
Instead of generating anchors for local types such as
`github.com/knative/eventing-contrib/camel/source/pkg/apis/sources/v1alpha1#CamelSource`
we can now just do `#sources.eventing.knative.dev/v1alpha1.CamelSource`
which has a longer shelf-life.

FYI @grantr 