### PR TITLE
Fix api group templating

### DIFF
--- a/template/pkg.tpl
+++ b/template/pkg.tpl
@@ -5,21 +5,23 @@
 <ul>
     {{ range . }}
     <li>
-        <a href="#{{- packageDisplayName . -}}">{{ packageDisplayName . }}</a>
+        <a href="#{{- packageAnchorID . -}}">{{ packageDisplayName . }}</a>
     </li>
     {{ end }}
 </ul>
 {{ end}}
 
 {{ range .packages }}
-    <h2 id="{{- packageDisplayName . -}}">
+    <h2 id="{{- packageAnchorID . -}}">
         {{- packageDisplayName . -}}
     </h2>
 
-    {{ with .DocComments }}
-    <p>
-        {{ safe (renderComments .) }}
-    </p>
+    {{ with (index .GoPackages 0 )}}
+        {{ with .DocComments }}
+        <p>
+            {{ safe (renderComments .) }}
+        </p>
+        {{ end }}
     {{ end }}
 
     Resource Types:


### PR DESCRIPTION
Two big fixes:

1. Prevent types in same apiGroup but different apiVersion (e.g v1beta1 vs
   v1alpha1) from grouped together.
2. De-duplicate liste apiGroups when types belonging to that api group come
   from different Go packages.

Signed-off-by: Ahmet Alp Balkan <ahmetb@google.com>