### PR TITLE
Add option to preserve trailing whitespace

### DIFF
--- a/main.go
+++ b/main.go
@@ -54,6 +54,9 @@ type generatorConfig struct {
 
 	// MarkdownDisabled controls markdown rendering for comment lines.
 	MarkdownDisabled bool `json:"markdownDisabled"`
+
+	// PreserveTrailingWhitespace controls retention of trailing whitespace in the rendered document.
+	PreserveTrailingWhitespace bool `json:"preserveTrailingWhitespace"`
 }
 
 type externalPackage struct {
@@ -139,6 +142,10 @@ func main() {
 		err := render(&b, apiPackages, config)
 		if err != nil {
 			return "", errors.Wrap(err, "failed to render the result")
+		}
+
+		if config.PreserveTrailingWhitespace {
+			return b.String(), nil
 		}
 
 		// remove trailing whitespace from each html line for markdown renderers
@@ -601,6 +608,7 @@ func render(w io.Writer, pkgs []*apiPackage, config generatorConfig) error {
 		"hiddenMember":     func(m types.Member) bool { return hiddenMember(m, config) },
 		"isLocalType":      isLocalType,
 		"isOptionalMember": isOptionalMember,
+		"safeIdentifier":   func(s string) string { return regexp.MustCompile("[[:punct:]]+").ReplaceAllLiteralString(s, "-") },
 	}).ParseGlob(filepath.Join(*flTemplateDir, "*.tpl"))
 	if err != nil {
 		return errors.Wrap(err, "parse error")


### PR DESCRIPTION
I am using my own set of templates to produce Asciidoc documents. Removing all trailing whitespace from the rendered document causes problems with Asciidoc rendering so this PR adds an option to preserve them.

It also adds a `safeIdentifier` template function to strip special characters from anchor identifiers. This is because some tools don't accept identifiers such as `type.domain.com/v1`