### PR TITLE
Add '// +gencrdrefdocs:force' marker to force generation for package without types

### DIFF
--- a/main.go
+++ b/main.go
@@ -36,6 +36,10 @@ var (
 	flOutFile  = flag.String("out-file", "", "path to output file to save the result")
 )
 
+const (
+	docCommentForceIncludes = "// +gencrdrefdocs:force"
+)
+
 type generatorConfig struct {
 	// HiddenMemberFields hides fields with specified names on all types.
 	HiddenMemberFields []string `json:"hideMemberFields"`
@@ -214,7 +218,7 @@ func parseAPIPackages(dir string) ([]*types.Package, error) {
 			continue
 		}
 
-		if groupName(pkg) != "" && len(pkg.Types) > 0 {
+		if groupName(pkg) != "" && len(pkg.Types) > 0 || containsString(pkg.DocComments, docCommentForceIncludes) {
 			klog.V(3).Infof("package=%v has groupName and has types", p)
 			pkgNames = append(pkgNames, p)
 		}
@@ -226,6 +230,15 @@ func parseAPIPackages(dir string) ([]*types.Package, error) {
 		pkgs = append(pkgs, scan[p])
 	}
 	return pkgs, nil
+}
+
+func containsString(sl []string, str string) bool {
+	for _, s := range sl {
+		if str == s {
+			return true
+		}
+	}
+	return false
 }
 
 // combineAPIPackages groups the Go packages by the <apiGroup+apiVersion> they


### PR DESCRIPTION
In cert-manager we maintain a [`meta/v1`](https://github.com/jetstack/cert-manager/tree/master/pkg/apis/meta/v1) package which defines some meta types which are shared between other types defined in other API groups.

Currently, these types are skipped because they do not contain any top-level types (`pkg.Types` contains no elements after parsing with gengo).

This PR adds support for a new marker in `doc.go` which forces a package to be considered as part of `parseAPIPackages`.

You can see a corresponding PR to add this marker here: https://github.com/jetstack/cert-manager/pull/2372

Once the above PR has merged, I'll be able to verify that this patch actually works 😄 

I'm not certain this approach is the best, but it provides a useful escape hatch to influence which packages are selected 😄 

cc @ahmetb 