### PR TITLE
Use all comments to get the group name

### DIFF
--- a/main.go
+++ b/main.go
@@ -185,9 +185,9 @@ func main() {
 }
 
 // groupName extracts the "//+groupName" meta-comment from the specified
-// package's godoc, or returns empty string if it cannot be found.
+// package's comments, or returns empty string if it cannot be found.
 func groupName(pkg *types.Package) string {
-	m := types.ExtractCommentTags("+", pkg.DocComments)
+	m := types.ExtractCommentTags("+", pkg.Comments)
 	v := m["groupName"]
 	if len(v) == 1 {
 		return v[0]


### PR DESCRIPTION
Instead of just using the godoc.

This change is backwards compatible. Note that in kubernetes/kubernetes the meta comments are not necessarily in the package's godoc.

https://github.com/kubernetes/kubernetes/blob/3842a92f5ffa7ceebf2058700c2494906f977800/staging/src/k8s.io/api/apps/v1/doc.go