### PR TITLE
Fix 404's that will happen with example config

### DIFF
--- a/example-config.json
+++ b/example-config.json
@@ -13,7 +13,7 @@
         },
         {
             "typeMatchPrefix": "^k8s\\.io/(api|apimachinery/pkg/apis)/",
-            "docsURLTemplate": "https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.13/#{{lower .TypeIdentifier}}-{{arrIndex .PackageSegments -1}}-{{arrIndex .PackageSegments -2}}"
+            "docsURLTemplate": "https://v1-17.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.17/#{{lower .TypeIdentifier}}-{{arrIndex .PackageSegments -1}}-{{arrIndex .PackageSegments -2}}"
         },
         {
             "typeMatchPrefix": "^github\\.com/knative/pkg/apis/duck/",


### PR DESCRIPTION
The K8s API reference docs no longer seem to support previous versions on the root, so this fix will point at 1.17, which is (a) a more up to date version and (b) one most cloud providers, at least in a preview state.