### PR TITLE
Standardize linebreak tags in templates

### DIFF
--- a/template/members.tpl
+++ b/template/members.tpl
@@ -4,7 +4,7 @@
 {{ if not (hiddenMember .)}}
 <tr>
     <td>
-        <code>{{ fieldName . }}</code></br>
+        <code>{{ fieldName . }}</code><br/>
         <em>
             {{ if linkForType .Type }}
                 <a href="{{ linkForType .Type}}">

--- a/template/type.tpl
+++ b/template/type.tpl
@@ -57,7 +57,7 @@
         {{ if isExportedType . }}
         <tr>
             <td>
-                <code>apiVersion</code></br>
+                <code>apiVersion</code><br/>
                 string</td>
             <td>
                 <code>
@@ -67,7 +67,7 @@
         </tr>
         <tr>
             <td>
-                <code>kind</code></br>
+                <code>kind</code><br/>
                 string
             </td>
             <td><code>{{.Name.Name}}</code></td>


### PR DESCRIPTION
Some of them were `</br>` instead of `<br/>`, which could lead to invalid XHTML
documents

Signed-off-by: Riccardo Binetti <rbino@gmx.com>