### PR TITLE
Allow disabling git commit info in output

### DIFF
--- a/main.go
+++ b/main.go
@@ -59,6 +59,9 @@ type generatorConfig struct {
 
 	// MarkdownDisabled controls markdown rendering for comment lines.
 	MarkdownDisabled bool `json:"markdownDisabled"`
+
+	// GitCommitDisabled causes the git commit information to be excluded from the output.
+	GitCommitDisabled bool `json:"gitCommitDisabled"`
 }
 
 type externalPackage struct {
@@ -685,7 +688,11 @@ func render(w io.Writer, pkgs []*apiPackage, config generatorConfig) error {
 		return errors.Wrap(err, "parse error")
 	}
 
-	gitCommit, _ := exec.Command("git", "rev-parse", "--short", "HEAD").Output()
+	var gitCommit []byte
+	if !config.GitCommitDisabled {
+		gitCommit, _ = exec.Command("git", "rev-parse", "--short", "HEAD").Output()
+	}
+
 	return errors.Wrap(t.ExecuteTemplate(w, "packages", map[string]interface{}{
 		"packages":  pkgs,
 		"config":    config,

--- a/template/placeholder.go
+++ b/template/placeholder.go
@@ -1,0 +1,2 @@
+// Placeholder file to make Go vendor this directory properly.
+package template


### PR DESCRIPTION
This allows running on every commit without unnecessarily creating a diff if the api types were not modified (which would allow us to run this script in `./hack/update-codegen.sh` along with all the other code generation we do). Wasn't sure if you'd prefer this as extra json config or as a flag, Ill happily change it to a flag if you'd prefer that.

Also adds a `placeholder.go` to the template directory so it gets properly vendored with `go mod vendor`, which avoids needing to clone a separate copy of the repo just to get the template dir.