### PR TITLE
Added one more level of deferencing when type is Slice of Pointers

### DIFF
--- a/main.go
+++ b/main.go
@@ -449,8 +449,8 @@ func linkForType(t *types.Type, c generatorConfig, typePkgMap map[*types.Type]*a
 
 // tryDereference returns the underlying type when t is a pointer, map, or slice.
 func tryDereference(t *types.Type) *types.Type {
-	if t.Elem != nil {
-		return t.Elem
+	for t.Elem != nil {
+		t = t.Elem
 	}
 	return t
 }
@@ -469,9 +469,11 @@ func finalUnderlyingTypeOf(t *types.Type) *types.Type {
 
 func typeDisplayName(t *types.Type, c generatorConfig, typePkgMap map[*types.Type]*apiPackage) string {
 	s := typeIdentifier(t)
+
 	if isLocalType(t, typePkgMap) {
 		s = tryDereference(t).Name.Name
 	}
+
 	if t.Kind == types.Pointer {
 		s = strings.TrimLeft(s, "*")
 	}


### PR DESCRIPTION
This PR adds the ability to deference any number of pointer levels when the type is Slice of Pointers `[]*Type` so that they are rendered correctly. This handles the issue #36 on the repo.