### PR TITLE
Allow version regex expression to support wider range of version expressions

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/super-harsh/gen-crd-api-reference-docs
+module github.com/ahmetb/gen-crd-api-reference-docs
 
 go 1.15
 

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/ahmetb/gen-crd-api-reference-docs
+module github.com/super-harsh/gen-crd-api-reference-docs
 
 go 1.15
 


### PR DESCRIPTION
This PR updates the version regex match to `^v\d+((alpha|beta)[a-z0-9]+)?$` to support wider range of version expressions. Which would help us in matching version expressions like `v1alpha1api20022020` in our project [Azure-Service-Operator](https://github.com/Azure/azure-service-operator).
