### PR TITLE
Fix the gencrdrefdocs:force comment

### DIFF
--- a/main.go
+++ b/main.go
@@ -38,7 +38,7 @@ var (
 )
 
 const (
-	docCommentForceIncludes = "// +gencrdrefdocs:force"
+	docCommentForceIncludes = "+gencrdrefdocs:force"
 )
 
 type generatorConfig struct {


### PR DESCRIPTION
The DocComments slice is provided without the comment prefix by gengo, so adding it to the package won't work. Here we fix it.
