### PR TITLE
YAML spec templates and supporting helpers

### DIFF
--- a/template/yaml/markdown/REAME.md
+++ b/template/yaml/markdown/REAME.md
@@ -1,0 +1,6 @@
+# Templates to produce a markdown API Document as YAML spec
+
+These templates are inspired by producing an API that is relevent to end users who are providing spec via a YAML file
+and not progammatically.  The Red Hat OpenShift 
+[AlertManager docs](https://docs.openshift.com/container-platform/4.11/rest_api/monitoring_apis/alertmanager-monitoring-coreos-com-v1.html#spec-affinity-nodeaffinity-preferredduringschedulingignoredduringexecution-preference-matchexpressions-2) 
+were used as reference 

--- a/template/yaml/markdown/members.tpl
+++ b/template/yaml/markdown/members.tpl
@@ -1,0 +1,65 @@
+{{ define "member" }}
+ {{ if not (eq .Type.Kind "Builtin") }}
+
+{{ if not (or (fieldEmbedded .Member) (hiddenMember .Member))}}
+### {{ .Path }}
+#### Description
+{{ (comments .CommentLines) }}
+####  Type
+{{ (yamlType .Type) }}
+
+{{ template "properties" .Type  }}
+
+{{ template "members" (nodeParent .Type .Path) }}
+
+
+
+{{ end }}
+{{ end }}
+{{ end }}
+
+{{ define "members" }}
+{{ $path := .Path }}
+{{ if .Members }}
+
+   {{ range .Members }}
+       {{ if (or (eq .Name "ObjectMeta") (eq (fieldName .) "TypeMeta")) }}
+        {{ else }}
+         {{if (eq (yamlType .Type) "array") }}
+             {{ $path := (printf "%s.%s[]" $path  (fieldName .)) }}
+             ### {{ $path }}
+             {{ template "type"  (nodeParent .Type.Elem $path ) }}
+         {{ else }}
+            {{ $path := (printf "%s.%s" $path  (fieldName .)) }}
+            {{ template "member" (node . $path) }}
+         {{ end }}
+       {{ end }}
+   {{ end }}
+
+{{ else if .Elem }}
+    {{ template "type" (nodeParent .Elem $path) }}
+{{ else }}
+{{end }}
+
+{{end }}
+
+
+{{ define "properties" }}
+{{ if .Members }}
+### Specification
+|Property|Type|Description|
+|---|---|---|
+   {{ range .Members }}
+       {{ if (or (or (eq (fieldName .) "metadata") (eq (fieldName .) "TypeMeta")) (ignoreMember .)) }}
+       {{ else }}
+           {{ if (isOptionalMember .) }}
+           |{{ (fieldName .) }}|{{ (yamlType .Type)}}| {{ (comments .CommentLines "summary")}}|
+           {{ else }}
+           |{{ (fieldName .) }}|{{ (yamlType .Type)}}| (optional) {{ (comments .CommentLines "summary")}}|
+           {{ end }}
+       {{ end }}
+   {{ end }}
+
+
+{{ end }}
+{{ end }}

--- a/template/yaml/markdown/pkg.tpl
+++ b/template/yaml/markdown/pkg.tpl
@@ -1,0 +1,32 @@
+{{ define "packages" }}
+
+{{ range .packages }}
+
+        {{ range (sortedTypes (visibleTypes .Types ))}}
+            {{ if isObjectRoot . }}
+
+            ##  {{ .Name.Name }}
+            ### Description
+            {{ (comments .CommentLines) }}
+            ###  Type
+            {{ (yamlType .) }}
+            ###  Required
+            {{ if .Members }}
+               {{ range .Members }}
+              {{ if (or (or (eq (fieldName .) "metadata") (eq (fieldName .) "TypeMeta")) (ignoreMember .)) }}
+              {{ else }}
+               * {{ (fieldName .) }}
+               {{ end }}
+               {{ end }}
+
+               {{ template "properties" .  }}
+
+               {{ template "members" (nodeParent . "") }}
+            {{ end }}
+
+            {{ end }}
+        {{ end }}
+{{ end }}
+
+{{ end }}
+

--- a/template/yaml/markdown/type.tpl
+++ b/template/yaml/markdown/type.tpl
@@ -1,0 +1,16 @@
+{{ define "type" }}
+
+### Description
+{{ (comments .CommentLines) }}
+###  Type
+{{ (yamlType .Type) }}
+
+{{ if .Members }}
+
+  {{ template "properties" .Type  }}
+  {{ template "members" (nodeParent .Type .Path) }}
+
+{{ end }}
+
+
+{{ end }}


### PR DESCRIPTION
This PR:

* Adds templates inspired by producing an API that is relevent to end users who are providing spec via a YAML file
and not progammatically.  
* Adds helper functions and structs to support the templates
* Inspired by https://docs.openshift.com/container-platform/4.11/rest_api/monitoring_apis/alertmanager-monitoring-coreos-com-v1.html#spec-affinity-nodeaffinity-preferredduringschedulingignoredduringexecution-preference-matchexpressions-2) 

Sample Result: https://github.com/jcantrill/cluster-logging-operator/blob/docgen/docs/operator/api.md

![image](https://user-images.githubusercontent.com/4548408/200935493-9b1745da-52ef-426b-894b-84c6a5ca83d0.png)
