### PR TITLE
Allow stable release versions in regex

### DIFF
--- a/main.go
+++ b/main.go
@@ -600,7 +600,7 @@ func isOptionalMember(m types.Member) bool {
 func apiVersionForPackage(pkg *types.Package) (string, string, error) {
 	group := groupName(pkg)
 	version := pkg.Name // assumes basename (i.e. "v1" in "core/v1") is apiVersion
-	r := `^v\d+((alpha|beta)[a-z0-9]+)?$`
+	r := `^v\d+((alpha|beta|api|stable)[a-z0-9]+)?$`
 	if !regexp.MustCompile(r).MatchString(version) {
 		return "", "", errors.Errorf("cannot infer kubernetes apiVersion of go package %s (basename %q doesn't match expected pattern %s that's used to determine apiVersion)", pkg.Path, version, r)
 	}


### PR DESCRIPTION
Modifies the regular expression used to identify package versions to also include `api` and `stable`, allowing for non-prerelease versions to be handled.

Motivated by 2.0.0 GA release of [Azure Service Operator](https://github.com/azure/azure-service-operator) where we have migrated our CRDs from `v1beta` as a prefix to `v1api`.