### PR TITLE
Bump GoReleaser config to v2

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,3 +1,4 @@
+version: 2
 builds:
   - env:
       - CGO_ENABLED=0


### PR DESCRIPTION
GorReleaser released version 2 which requires a bump in the config